### PR TITLE
Fix node runtime version

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -8,7 +8,7 @@ Resources:
     Properties:
       CodeUri: ./build
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       MemorySize: 128
       Timeout: 30000
       Events:


### PR DESCRIPTION
Was getting `ValueError: Unsupported Lambda runtime nodejs8.10` when doing `npm start` to run function locally.
I'm not sure if `nodejs8.10` is correct syntax for SAM template file, changing it to `nodejs12.x` works.